### PR TITLE
Actualizar versión de build_images

### DIFF
--- a/firestarter/workflows/build_images/build_images.py
+++ b/firestarter/workflows/build_images/build_images.py
@@ -7,6 +7,7 @@ from .providers.registries.factory import DockerRegistryAuthFactory
 from .providers.secrets.resolver import SecretResolver
 from .config import Config
 import docker
+from ast import literal_eval
 import uuid
 from os import remove, getcwd
 
@@ -15,27 +16,44 @@ class BuildImages(FirestarterWorkflow):
         super().__init__(**kwargs)
         self._secrets = self.resolve_secrets()
         self._repo_name = self.vars['repo_name']
-        self._from_point = self.vars['from_point']
-        self._on_premises = self.vars['on_premises']
+        self._snapshots_registry = self.vars['snapshots_registry']
+        self._releases_registry = self.vars['releases_registry']
+        self._type = self.vars['type']
+        self._from = self.vars['from']
+        self._flavors = self.vars['flavors'] if 'flavors' in self.vars else 'default'
         self._container_structure_filename = self.vars['container_structure_filename'] if 'container_structure_filename' in self.vars else None
         self._dagger_secrets = []
-        self._login_required = self.vars['login_required'] if 'login_required' in self.vars else True
+        self._login_required = literal_eval(
+            self.vars['login_required'].capitalize()) if 'login_required' in self.vars else True
         self._publish = self.vars['publish'] if 'publish' in self.vars else True
 
         # Read the on-premises configuration file
-        self._config = Config.from_yaml(self.config_file)
+        self._config = Config.from_yaml(self.config_file, self.type)
 
     @property
     def repo_name(self):
         return self._repo_name
 
     @property
-    def from_point(self):
-        return self._from_point
+    def snapshots_registry(self):
+        return self._snapshots_registry
 
     @property
-    def on_premises(self):
-        return self._on_premises
+    def releases_registry(self):
+        return self._releases_registry
+
+    @property
+    def type(self):
+        return self._type
+
+    # Cannot use from property as it is a reserved keyword
+    @property
+    def from_version(self):
+        return self._from
+
+    @property
+    def flavors(self):
+        return self._flavors
 
     @property
     def container_structure_filename(self):
@@ -61,14 +79,14 @@ class BuildImages(FirestarterWorkflow):
         sr = SecretResolver(self.secrets)
         return sr.resolve()
 
-    def filter_on_premises(self):
+    def filter_flavors(self):
         # Get the on-premises name from the command-line arguments and filter the on-premises data accordingly
-        if self.on_premises is not None:
-            if self.on_premises == '*':
-                print('Publishing to all on-premises:')
-                self._on_premises = ",".join(list(self.config.images.keys()))
+        if self.flavors is not None:
+            if self.flavors == '*':
+                print('Publishing all flavors:')
+                self._flavors = ",".join(list(self.config[self.type].keys()))
 
-            self._on_premises = self.on_premises.replace(' ', '').split(',')
+            self._flavors = self.flavors.replace(' ', '').split(',')
 
 
     async def test_image(self, ctx):
@@ -109,7 +127,7 @@ class BuildImages(FirestarterWorkflow):
         ctx = (
             ctx.container()
                 .build(context=src, dockerfile=dockerfile, build_args=build_args, secrets=self.dagger_secrets)
-                .with_label("source.code.revision", self.from_point)
+                .with_label("source.code.revision", self.from_version)
                 .with_label("repository.name", self.repo_name)
                 .with_label("build.date", datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S_UTC"))
         )
@@ -121,7 +139,7 @@ class BuildImages(FirestarterWorkflow):
             await ctx.publish(address=f"{image}")
 
     # Define a coroutine function to execute the compilation process for all on-premises
-    async def compile_images_for_all_on_premises(self):
+    async def compile_images_for_all_flavors(self):
         # Set up the Dagger configuration object
         config = dagger.Config(log_output=sys.stdout)
 
@@ -132,13 +150,12 @@ class BuildImages(FirestarterWorkflow):
             for key, value in self.secrets.items():
                 self._dagger_secrets.append(client.set_secret(key, value))
 
-            # Set up a task group to execute the compilation process for all on-premises in parallel
+            # Set up a task group to execute the compilation process for all flavors in parallel
             async with anyio.create_task_group() as tg:
-                for on_prem in self.on_premises:
-                    value = self.config.images[on_prem]
+                for flavor in self.flavors:
+                    value = self.config.images[flavor]
                     # Get the registry, repository, build arguments, Dockerfile path, and address for the current on-premises
-                    registry = value.registry
-                    repository = value.repository
+                    registry = self.vars[f"{self.type}_registry"]
                     build_args = value.build_args or {}
                     dockerfile = value.dockerfile or ""
 
@@ -146,31 +163,31 @@ class BuildImages(FirestarterWorkflow):
                     build_args_list = [dagger.BuildArg(name=key, value=value) for key, value in build_args.items()]
 
                     # Set the address for the current on-premises
-                    address = f"{registry}/{repository}"
-                    image = f"{address}:{self.from_point}"
+                    address = f"{registry}/{self.repo_name}"
+                    image = f"{address}:{self.from_version}_{flavor}"
 
                     # Print the current on-premises data
-                    print(f'\nOn-premise: {on_prem.upper()}')
+                    print(f'\nOn-premise: {flavor.upper()}')
                     print(f'\tRegistry: {registry}')
-                    print(f'\tRepository: {repository}')
+                    print(f'\tRepository: {self.repo_name}')
                     if build_args != {}:
                         print(f'\tBuild args: {build_args}')
                     print(f'\tDockerfile: {dockerfile}')
-                    print(f'\tImage name: {address}:{self.from_point}')
+                    print(f'\tImage name: {image}')
 
                     await tg.spawn(self.compile_image_and_publish, client, build_args_list, dockerfile, image)
 
 
     def execute(self):
-        self.filter_on_premises()
+        self.filter_flavors()
 
-        print(f"Building '{self.repo_name}' from '{self.from_point}' for '{self.on_premises}'")
-        
-        # Log in to the Azure Container Registry for each on-premises active in the configuration file
-        for key in self.on_premises:
-            on_prem = self.config.images[key]
-            provider = DockerRegistryAuthFactory.provider_from_str(on_prem.auth_strategy, on_prem.registry)
-            provider.login_registry()
+        if self.login_required:
+            # Log in to the Azure Container Registry for each on-premises active in the configuration file
+            for key in self.flavors:
+                flavor = self.config.images[key]
+                provider = DockerRegistryAuthFactory.provider_from_str(
+                    flavor.auth_strategy, flavor.registry)
+                provider.login_registry()
 
         # Run the coroutine function to execute the compilation process for all on-premises
-        anyio.run(self.compile_images_for_all_on_premises)
+        anyio.run(self.compile_images_for_all_flavors)

--- a/firestarter/workflows/build_images/config.py
+++ b/firestarter/workflows/build_images/config.py
@@ -5,29 +5,29 @@ import yaml
 
 @dataclass
 class Image:
-    registry: str
-    repository: str
+    build_always: bool = field(default=True)
+    extra_registries: dict = field(default_factory=dict)
     build_args: dict = field(default_factory=dict)
+    secrets: dict = field(default_factory=dict)
     dockerfile: str = field(default="Dockerfile")
-    auth_strategy: str = field(default="none")
 
     @classmethod
     def from_dict(cls: t.Type["Image"], obj: dict):
         return cls(
-            registry=obj.get("registry"),
-            repository=obj.get("repository"),
+            build_always=obj.get("build_always"),
+            extra_registries=obj.get("extra_registries"),
             build_args=obj.get("build_args"),
+            secrets=obj.get("secrets"),
             dockerfile=obj.get("dockerfile"),
-            auth_strategy=obj.get("auth_strategy"),
         )
 
     def to_dict(self):
         return {
-            "registry": self.registry,
-            "repository": self.repository,
+            "build_always": self.build_always,
+            "extra_registries": self.extra_registries,
             "build_args": self.build_args,
+            "secrets": self.secrets,
             "dockerfile": self.dockerfile,
-            "auth_strategy": self.auth_strategy,
         }
 
 @dataclass
@@ -37,14 +37,15 @@ class Config:
     @classmethod
     def from_dict(cls: t.Type["Config"], obj: dict):
         return cls(
-            images={id: Image.from_dict(image) for id, image in obj.get("images", {}).items()}
+            images={id: Image.from_dict(image) for id, image in obj.items()}
         )
 
     @classmethod
-    def from_yaml(cls: t.Type["Config"], file: str):
+    def from_yaml(cls: t.Type["Config"], file: str, type: str):
         with open(file, "r") as f:
             raw_config = yaml.safe_load(f)
-        return cls.from_dict(raw_config)
+        config = cls.from_dict(raw_config[type])
+        return config
 
     def to_dict(self):
         return {


### PR DESCRIPTION
Como se menciono en la issue de daggerverse ( prefapp/daggerverse#1 ) hay que actualizar el workflow para que cumpla con la siguiente configuración:

```yaml
snapshots:
 default:
    build_args:
      ARG_1: "VALUE_A"
    dockerfile: ./Dockerfile

 other-flavor:
    build_args:
      ARG_2: "VALUE_2"
    dockerfile: ./Dockerfile

releases:
  default:
    build-always: true
    extra-registries:
      - name: releases-prefapp-extra.azurecr.io
        repository: prefapp/mi-app
    build_args:
      GENERATE_SOURCEMAP: "true"
    secrets:
     MY_TOKEN: my-keyvault.vault.azure.net/secrets/my-token
     AWS_TOKEN: arn:...:parameters/my-token
    dockerfile: docker/Dockerfile

```

Esto se probo en el repo de prefapp/test-repo-rundagger con el siguiente comando:

```
poetry run -C .dagger/ firestarter build_images --vars='vars={repo_name="foo", flavors="default,other-flavor", snapshots_registry="ttl.sh", releases_registry="ttl.sh", type="snapshots", from="main", login_required="False"}' --config_file .dagger/firestarter_build_images.yaml
```
