### PR TITLE
Fix error when the app does not match exactly with the release

### DIFF
--- a/.github/workflows/state-repo-helm-apps.yaml
+++ b/.github/workflows/state-repo-helm-apps.yaml
@@ -218,7 +218,7 @@ jobs:
           </details>
           EOF
             else
-              echo "⚠️ Installing for the first time $appname ⚠️"
+              echo "⚠️ Installing $appname for the first time ⚠️"
             fi
 
           done

--- a/.github/workflows/state-repo-helm-apps.yaml
+++ b/.github/workflows/state-repo-helm-apps.yaml
@@ -205,13 +205,12 @@ jobs:
             # Verify the app exists or if it is the first time it's been applied
             appname=$(echo $app | awk -F"/" '{print $NF}')
 
-            releases_found=`helm list -A -o json | jq "map(select(.name == \"$appname\" and (.namespace | contains(\"${{ inputs.environment }}\")) )) | length"`
-            
+            releases_found=`helm list -A -o json | jq "map(select( (.name | contains(\"$appname\")) and (.namespace | contains(\"${{ inputs.environment }}\")) )) | length"`
             if [ $releases_found -gt 0 ]; then
               diff_output=`helmfile --environment ${{ inputs.environment }} diff --context 5 | grep --color=never "\S"`
               cat <<EOF >> $DIFF_FILE
           <details>
-          <summary><h2> Helm diff in env: ${{ inputs.environment }}, app: $appname,</h2></summary>
+          <summary><h2> Helm diff in env: ${{ inputs.environment }}, app: $appname</h2></summary>
 
             \`\`\`diff
             $(echo "$diff_output" | sed 's/^/  /')
@@ -219,7 +218,7 @@ jobs:
           </details>
           EOF
             else
-              echo 'Installing for the first time'
+              echo "⚠️ Installing for the first time $appname ⚠️"
             fi
 
           done

--- a/.github/workflows/state-repo-helm-apps.yaml
+++ b/.github/workflows/state-repo-helm-apps.yaml
@@ -205,7 +205,7 @@ jobs:
             # Verify the app exists or if it is the first time it's been applied
             appname=$(echo $app | awk -F"/" '{print $NF}')
 
-            releases_found=`helm list -A -o json | jq "map(select( (.name | contains(\"$appname\")) and (.namespace | contains(\"${{ inputs.environment }}\")) )) | length"`
+            releases_found=`helmfile --environment ${{ inputs.environment }} list | awk '$4 == "true"' | wc -l`s
             if [ $releases_found -gt 0 ]; then
               diff_output=`helmfile --environment ${{ inputs.environment }} diff --context 5 | grep --color=never "\S"`
               cat <<EOF >> $DIFF_FILE

--- a/.github/workflows/state-repo-helm-sys-services.yaml
+++ b/.github/workflows/state-repo-helm-sys-services.yaml
@@ -128,7 +128,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          diff_file="/tmp/helmfile.md"
+          DIFF_FILE="/tmp/helmfile.md"
 
           cd ${{ github.workspace }}/sys_services
 
@@ -147,13 +147,15 @@ jobs:
             
             if [ $releases_found -gt 0 ]; then
               diff_output=`helmfile --environment ${{ inputs.environment }} --selector release=$appname diff --detailed-exitcode --context 5 | grep --color=never "\S"`
-              cat <<EOF > $diff_file
-          # Helm diff in app: $appname, env: ${{ inputs.environment }}
-          \`\`\`diff
-          $diff_output
-          \`\`\`
+              cat <<EOF >> $DIFF_FILE
+          <details>
+          <summary><h2> Helm diff in app: $appname, env: ${{ inputs.environment }}</h2></summary>
+
+            \`\`\`diff
+            $(echo "$diff_output" | sed 's/^/  /')
+            \`\`\`
           EOF
-              gh pr comment ${{ github.event.number }} -F $diff_file
+              gh pr comment ${{ github.event.number }} -F $DIFF_FILE
             else
               echo 'Installing for the first time'
             fi


### PR DESCRIPTION
* In case there is something prepended to the release name that is not specified in the state repo's folder name it has been switch from a strict comparison to just check if the word is contained
* Made the log for first releases more striking
* Added the same diff format to sys services as the one we had in regular apps