### PR TITLE
feat: Add state repo workflows documentation

### DIFF
--- a/docs/state-repo-analyze-changes.md
+++ b/docs/state-repo-analyze-changes.md
@@ -1,0 +1,41 @@
+# State Repo Analyze Changes
+
+## Description
+
+This workflow is used to analyze what changes are present based on the following structure of folders:
+
+```md
+apps
+└── tenant
+    └── app-name
+        └── environment
+            ├── deployment.yaml
+            └── configmap.yaml
+sys-services
+└── sys-service-name
+    └── cluster-name
+```
+
+The output of this workflow is a JSON object with the structure below:
+
+* Apps
+
+```json
+{
+    "<ENVIRONMENT>": {
+        "environment": "<ENVIRONMENT>",
+        "updated_apps": ["apps/<TENANT>/<APP_NAME>"]
+    }
+}
+```
+
+* Sys Services
+
+```json
+{
+    "<CLUSTER_NAME>": {
+        "cluster_name": "<CLUSTER_NAME>",
+        "updated_sys_services": ["sys_services/<SYS_SERVICE_NAME>"]
+    }
+}
+```

--- a/docs/state-repo-helm.md
+++ b/docs/state-repo-helm.md
@@ -1,0 +1,64 @@
+# State Repo Helm
+
+## Description
+
+This workflow is used to:
+
+1. Check pull request for changes in the deployments and write the changes in a comment.
+2. Deploy the changes to the cluster
+
+## Configuration
+
+There are two workflows that are used to deploy the state repository.
+
+1. **state-repo-helm-apps** - This workflow is used to app services.
+2. **state-repo-helm-sys-services** - This workflow is used to deploy system services.
+
+Each of these workflows require a specific configuration file to be present in the repository under the `.github` directory.
+
+1. **apps-config.yaml**.
+2. **sys-services-config.yaml**.
+
+Both of these files follow the same structure, some fields vary depending on the cloud provider.
+
+### Azure
+
+```yaml
+provider:
+  kind: azure
+  tenant_id: ca5a6690-2f48-4776-91dd-8fde1d02e7e8
+  subscription_id: c8e19171-5128-483c-8a35-e8deabb4f519
+helm_registries:
+  - cbxacr.azurecr.io
+  - acrnoreleases.azurecr.io
+  - acrreleases.azurecr.io
+environments:
+  dev:
+    cluster_name: tgss-predev-aks
+    resource_group_name: tgss-common-predev
+    identifier: bdc3cb69-f169-44fe-8dc2-cfb1e8ee44c9
+  pre:
+    cluster_name: tgss-predev-aks
+    resource_group_name: tgss-common-predev
+    identifier: bdc3cb69-f169-44fe-8dc2-cfb1e8ee44c9
+  pro:
+    cluster_name: tgss-pro-aks
+    resource_group_name: tgss-common-pro
+    identifier: bdc3cb69-f169-44fe-8dc2-cfb1e8ee44c9
+  
+```
+
+### AWS
+
+```yaml
+provider:
+  kind: aws
+  role-to-assume: <ROLE_TO_ASSUME_ARN>
+  region: us-west-2
+helm_registries:
+  - <AWS_ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
+environments:
+    dev:
+        cluster_name: tgss-dev-eks
+        identifier: <IDENTIFIER>
+```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -5,8 +5,7 @@ nav:
   - Introduction: index.md
   - Reusable Workflows:
     - State Repo Analyze Changes: state-repo-analyze-changes.md
-    - State Repo Helm Apps: state-repo-helm-apps.md
-    - State Repo Helm Sys Services: state-repo-helm-sys-services.md
+    - State Repo Helm: state-repo-helm.md
 
 plugins:
   - techdocs-core

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -3,6 +3,10 @@ site_description: "Custom documentation"
 
 nav:
   - Introduction: index.md
+  - Reusable Workflows:
+    - State Repo Analyze Changes: state-repo-analyze-changes.md
+    - State Repo Helm Apps: state-repo-helm-apps.md
+    - State Repo Helm Sys Services: state-repo-helm-sys-services.md
 
 plugins:
   - techdocs-core


### PR DESCRIPTION
It was necesary to have documentation in state repo workflows in order to add a link to it when automatically deploying these workflows as a solution to the issues described in this [comment](https://github.com/prefapp/features/issues/284#issuecomment-2331101633)